### PR TITLE
fix: Rename server name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@ const {AutoLanguageClient} = require('atom-languageclient')
 class JSONLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return ['source.json'] }
   getLanguageName () { return 'JSON' }
-  getServerName () { return 'ide-json' }
+  getServerName () { return 'VSC JSON Language Server' }
 
   startServerProcess () {
     return super.spawnChildNode([ require.resolve('vscode-json-languageserver-bin/jsonServerMain'), '--stdio' ]);

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@ const {AutoLanguageClient} = require('atom-languageclient')
 class JSONLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return ['source.json'] }
   getLanguageName () { return 'JSON' }
-  getServerName () { return 'VSCode' }
+  getServerName () { return 'ide-json' }
 
   startServerProcess () {
     return super.spawnChildNode([ require.resolve('vscode-json-languageserver-bin/jsonServerMain'), '--stdio' ]);


### PR DESCRIPTION
Currently, when there is an error in a json file, the overlay states the error is coming from `VSCode`, this is a rather odd user experience since we're not consciously running anything to do with VSCode and the user only knows about the package as `ide-json`

![image](https://user-images.githubusercontent.com/3392349/40469524-b6c08296-5ee5-11e8-978c-6b11c60580ee.png)
